### PR TITLE
feat: Add public attribute exposing pre-fit label encoder

### DIFF
--- a/pyuoi/linear_model/logistic.py
+++ b/pyuoi/linear_model/logistic.py
@@ -19,6 +19,7 @@ import numpy as np
 from .base import AbstractUoIGeneralizedLinearRegressor
 from ..utils import sigmoid, softmax
 from ..lbfgs import fmin_lbfgs, AllZeroLBFGSError
+from typing import Optional
 
 
 class UoI_L1Logistic(AbstractUoIGeneralizedLinearRegressor, LogisticRegression):
@@ -149,6 +150,7 @@ class UoI_L1Logistic(AbstractUoIGeneralizedLinearRegressor, LogisticRegression):
             fit_intercept=fit_intercept,
             max_iter=max_iter,
             tol=tol)
+        self.label_encoder: Optional[LabelEncoder] = None
 
     def get_reg_params(self, X, y):
         input_dim = X.shape[1]
@@ -200,6 +202,7 @@ class UoI_L1Logistic(AbstractUoIGeneralizedLinearRegressor, LogisticRegression):
     def _pre_fit(self, X, y):
         X, y = super()._pre_fit(X, y)
         le = LabelEncoder()
+        self.label_encoder = le
         y = le.fit_transform(y)
         self.classes_ = le.classes_
         if self.classes_.size > 2:


### PR DESCRIPTION
In order to convert transformed labeled values back into their human-readable behavior labels, we need to expose the pre-fit label encoder in order to do the inverse transform. Pre-requisite before merging PR #4. We should add some tests also to check that we are currently using the correct label encoder, as I saw that there were multiple instances of a label encoder in the base model file.